### PR TITLE
Update Package.swift

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -27,7 +27,7 @@ let package = Package(
   ],
   targets: [
     .binaryTarget(
-      name: "GoogleInteractiveMediaAds",
+      name: "GoogleInteractiveMediaAdsTvOS",
       url: "https://imasdk.googleapis.com/native/downloads/ima-tvos-v4.11.1.zip",
       checksum: "fbd68a6331cabd9047539017ac16327790b46a01ea1e6ac13ab78ef82d496b9c"
     )

--- a/Package.swift
+++ b/Package.swift
@@ -17,12 +17,12 @@
 import PackageDescription
 
 let package = Package(
-  name: "GoogleInteractiveMediaAds",
+  name: "GoogleInteractiveMediaAdsTvOS",
   platforms: [.tvOS(.v11)],
   products: [
     .library(
-      name: "GoogleInteractiveMediaAds",
-      targets: ["GoogleInteractiveMediaAds"]
+      name: "GoogleInteractiveMediaAdsTvOS",
+      targets: ["GoogleInteractiveMediaAdsTvOS"]
     )
   ],
   targets: [


### PR DESCRIPTION
Update the package name to add "TvOS" so that this package can be used concurrently with the iOS package.

Currently if you try to install Google IMA for iOS & tvOS into the same project, Xcode throws an error that the packages have the same name. This fixes that issue.